### PR TITLE
Add new error messages

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"timonwong.shellcheck"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+		
+	]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,13 +1,4 @@
 {
-	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
-	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
-
-	// List of extensions which should be recommended for users of this workspace.
-	"recommendations": [
-		"timonwong.shellcheck"
-	],
-	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
-	"unwantedRecommendations": [
-		
-	]
+	"recommendations": ["timonwong.shellcheck"],
+	"unwantedRecommendations": []
 }

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -26,8 +26,8 @@ NOW_ISO=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 GITHUB_AUTH_HEADER="Authorization: token $GITHUB_OAUTH_TOKEN"
 RELEASES_API="https://api.github.com/repos/$REPOSITORY/releases"
 
-CURL_RESPONSE=`curl -s -H "$GITHUB_AUTH_HEADER" "$RELEASES_API/tags/$VERSION"`
-ERROR_MESSAGE=`echo $CURL_RESPONSE | jq ".message"`
+CURL_RESPONSE=$(curl -s -H "$GITHUB_AUTH_HEADER" "$RELEASES_API/tags/$VERSION")
+ERROR_MESSAGE=$(echo "$CURL_RESPONSE" | jq ".message")
 
 if [ "$ERROR_MESSAGE" == "\"Bad credentials\"" ]; then
     echo "Error: Invalid GITHUB_OAUTH_TOKEN"
@@ -40,7 +40,7 @@ elif [ "$ERROR_MESSAGE" != "null" ]; then
     exit 1
 fi
 
-ASSET_ID=`echo $CURL_RESPONSE | jq ".assets[0].id"`
+ASSET_ID=$(echo "$CURL_RESPONSE" | jq ".assets[0].id")
 DEPLOY_DIR="deploy"
 DEPLOY_ZIP="$DEPLOY_DIR.zip"
 

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -26,8 +26,8 @@ NOW_ISO=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 GITHUB_AUTH_HEADER="Authorization: token $GITHUB_OAUTH_TOKEN"
 RELEASES_API="https://api.github.com/repos/$REPOSITORY/releases"
 
-CURL_RESPONSE=$(curl -s -H "$GITHUB_AUTH_HEADER" "$RELEASES_API/tags/$VERSION")
-ERROR_MESSAGE=$(echo "$CURL_RESPONSE" | jq ".message")
+VERSION_DETAILS_IN_JSON=$(curl -s -H "$GITHUB_AUTH_HEADER" "$RELEASES_API/tags/$VERSION")
+ERROR_MESSAGE=$(echo "$VERSION_DETAILS_IN_JSON" | jq ".message")
 
 if [ "$ERROR_MESSAGE" == "\"Bad credentials\"" ]; then
     echo "Error: Invalid GITHUB_OAUTH_TOKEN"
@@ -40,7 +40,7 @@ elif [ "$ERROR_MESSAGE" != "null" ]; then
     exit 1
 fi
 
-ASSET_ID=$(echo "$CURL_RESPONSE" | jq ".assets[0].id")
+ASSET_ID=$(echo "$VERSION_DETAILS_IN_JSON" | jq ".assets[0].id")
 DEPLOY_DIR="deploy"
 DEPLOY_ZIP="$DEPLOY_DIR.zip"
 

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -25,7 +25,22 @@ ENVIRONMENT=$3
 NOW_ISO=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 GITHUB_AUTH_HEADER="Authorization: token $GITHUB_OAUTH_TOKEN"
 RELEASES_API="https://api.github.com/repos/$REPOSITORY/releases"
-ASSET_ID=$(curl -s -H "$GITHUB_AUTH_HEADER" "$RELEASES_API/tags/$VERSION" | jq ".assets[0].id")
+
+CURL_RESPONSE=`curl -s -H "$GITHUB_AUTH_HEADER" "$RELEASES_API/tags/$VERSION"`
+ERROR_MESSAGE=`echo $CURL_RESPONSE | jq ".message"`
+
+if [ "$ERROR_MESSAGE" == "\"Bad credentials\"" ]; then
+    echo "Error: Invalid GITHUB_OAUTH_TOKEN"
+    exit 1
+elif [ "$ERROR_MESSAGE" == "\"Not found\"" ]; then
+    echo "Error: Could not find github repository, ensure the GITHUB_OAUTH_TOKEN and the VERSION are correct"
+    exit 1
+elif [ "$ERROR_MESSAGE" != "null" ]; then
+    echo "Error getting github repository: ${ERROR_MESSAGE}"
+    exit 1
+fi
+
+ASSET_ID=`echo $CURL_RESPONSE | jq ".assets[0].id"`
 DEPLOY_DIR="deploy"
 DEPLOY_ZIP="$DEPLOY_DIR.zip"
 


### PR DESCRIPTION
Check the curl response to github to check for errors.

A Bad credentials response means there was an issue with the GITHUB_OAUTH_TOKEN argument
Not found is likely due to an issue with the VERSION argument, but a poorly formed GITHUB_OAUTH_TOKEN can give that message too.
For other non-null error messages display the message itself.