### PR TITLE
Copy env files on deploy

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -48,6 +48,12 @@ curl -sL -H "$GITHUB_AUTH_HEADER" -H "Accept: application/octet-stream" "$RELEAS
 rm -rf $DEPLOY_DIR
 unzip $DEPLOY_ZIP -d $DEPLOY_DIR
 rm -rf $DEPLOY_ZIP
+
+# Copy any .env files to deploy dir
+if ls '.env'* 1> /dev/null 2>&1; then
+    cp '.env'* $DEPLOY_DIR 
+fi
+
 cd $DEPLOY_DIR
 yarn install -s --no-progress --frozen-lockfile
 DEPLOYED_DATE=$NOW_ISO yarn run sls deploy --stage "$ENVIRONMENT" --verbose

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totallymoney/github-serverless-dotnet-artifacts",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Use github releases to publish and deploy serverless framework dotnet projects",
   "type": "module",
   "author": "totallymoney",


### PR DESCRIPTION
https://www.serverless.com/framework/docs-environment-variables

when useDotenv is set to true, Serverless will look in the root directory for any .env files and use them to populate env parameters, during the deploy process, serverless will look in the deploy dir, not see any .env files and fail

This PR copies the .env files to the deploy directory if any exist