### PR TITLE
Use gh cli tool for github interactions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
+    "source.fixAll.eslint": "explicit"
   },
   "editor.formatOnSave": true
 }

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,54 +1,27 @@
 #!/bin/bash
 
-set -e
+set -ex
 
-REQUIREMENTS="jq yarn dotnet curl"
+REQUIREMENTS="gh yarn"
 for i in $REQUIREMENTS; do
-    hash "$i" 2>/dev/null || { echo "$0": I require "$i" but it\'s not installed.; exit 1; }
+  hash "$i" 2>/dev/null || { echo "$0": I require "$i" but it\'s not installed.; exit 1; }
 done
 
-if [ $# -ne 3 ]; then
-    echo "$0": usage: deploy.sh REPOSITORY VERSION ENVIRONMENT
-    echo "$0": eg: deploy.sh mediaingenuity/myrepo 1.2.3456 stage
-    exit 1
+if [ $# -ne 2 ]; then
+  echo "$0": usage: deploy.sh VERSION ENVIRONMENT
+  echo "$0": eg: deploy.sh 1.2.3 stage
+  exit 1
 fi
 
-if [ -z "$GITHUB_OAUTH_TOKEN" ]; then
-    echo "Need to set GITHUB_OAUTH_TOKEN"
-    exit 1
-fi
-
-REPOSITORY=$1
-export VERSION=$2
-ENVIRONMENT=$3
-
+VERSION=$1
+ENVIRONMENT=$2
 NOW_ISO=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-GITHUB_AUTH_HEADER="Authorization: token $GITHUB_OAUTH_TOKEN"
-RELEASES_API="https://api.github.com/repos/$REPOSITORY/releases"
 
-VERSION_DETAILS_IN_JSON=$(curl -s -H "$GITHUB_AUTH_HEADER" "$RELEASES_API/tags/$VERSION")
-ERROR_MESSAGE=$(echo "$VERSION_DETAILS_IN_JSON" | jq ".message")
-
-if [ "$ERROR_MESSAGE" == "\"Bad credentials\"" ]; then
-    echo "Error: Invalid GITHUB_OAUTH_TOKEN"
-    exit 1
-elif [ "$ERROR_MESSAGE" == "\"Not found\"" ]; then
-    echo "Error: Could not find github repository, ensure the GITHUB_OAUTH_TOKEN and the VERSION are correct"
-    exit 1
-elif [ "$ERROR_MESSAGE" != "null" ]; then
-    echo "Error getting github repository: ${ERROR_MESSAGE}"
-    exit 1
-fi
-
-ASSET_ID=$(echo "$VERSION_DETAILS_IN_JSON" | jq ".assets[0].id")
-DEPLOY_DIR="deploy"
-DEPLOY_ZIP="$DEPLOY_DIR.zip"
-
-curl -sL -H "$GITHUB_AUTH_HEADER" -H "Accept: application/octet-stream" "$RELEASES_API/assets/$ASSET_ID" -o "$DEPLOY_ZIP"
-rm -rf $DEPLOY_DIR
-unzip $DEPLOY_ZIP -d $DEPLOY_DIR
-rm -rf $DEPLOY_ZIP
-cd $DEPLOY_DIR
-yarn install -s --no-progress --frozen-lockfile
+rm -rf ./deploy ./deploy.zip
+gh release download "$VERSION" --output deploy.zip
+unzip ./deploy.zip -d ./deploy
+cd ./deploy
+yarn install --silent --no-progress --frozen-lockfile
 DEPLOYED_DATE=$NOW_ISO yarn run sls deploy --stage "$ENVIRONMENT" --verbose
 cd .. || exit
+rm -rf ./deploy ./deploy.zip

--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -1,86 +1,35 @@
 #!/bin/bash
 
-set -e
+set -ex
 
-REQUIREMENTS="jq yarn dotnet curl"
+REQUIREMENTS="gh dotnet"
 for i in $REQUIREMENTS; do
-    hash "$i" 2>/dev/null || { echo "$0": I require "$i" but it\'s not installed.; exit 1; }
+  hash "$i" 2>/dev/null || { echo "$0": I require "$i" but it\'s not installed.; exit 1; }
 done
 
-if [ $# -ne 4 ]; then
-    echo "$0": usage: publish.sh REPOSITORY PROJECT VERSION COMMIT
-    echo "$0": eg: publish.sh mediaingenuity/myrepo src 1.2.3456 master
-    echo "$0": OR
-    echo "$0": eg: publish.sh mediaingenuity/myrepo path/to/project.fsproj 1.2.3456 b7232ef30b17afbe6d6b4703784cd5e69956e104
-    exit 1
+if [ $# -eq 0 ]; then
+  echo "$0": "usage: publish.sh VERSION [ -p project ]" >&2
+  echo "$0": "eg: publish.sh 1.2.3" >&2
+  echo "$0": "eg: publish.sh 1.2.3 -p project/dir" >&2
+  exit 1
 fi
 
-if [ -z "$GITHUB_OAUTH_TOKEN" ]; then
-    echo "Need to set GITHUB_OAUTH_TOKEN"
-    exit 1
-fi
+VERSION=$1
+shift
 
-REPOSITORY=$1
-PROJECT=$2
-VERSION=$3
-COMMIT=$4
-PUBLISH_DIR="publish"
-PUBLISH_ZIP="$VERSION.zip"
+PROJECT=./src
+while getopts "p::" opt; do
+  case $opt in
+    p) PROJECT=${OPTARG} ;;
+    *) ;;
+  esac
+done
 
-rm -rf $PUBLISH_DIR
-mkdir $PUBLISH_DIR
-dotnet lambda package "$PUBLISH_DIR/package.zip" \
-  -pl "$PROJECT" -c Release -farch "arm64" --msbuild-parameters "/p:PublishReadyToRun=true"
-cp serverless.yml "$PUBLISH_DIR/serverless.yml"
-cp package.json "$PUBLISH_DIR/package.json"
-cp yarn.lock "$PUBLISH_DIR/yarn.lock"
-[ -d "./serverless-artifacts" ] && cp -r serverless-artifacts "$PUBLISH_DIR"
-cd $PUBLISH_DIR
-zip -r "$PUBLISH_ZIP" .
-cd .. || exit
-
-LATEST_TAG="$(git describe --tags --abbrev=0)"
-MSGS_SINCE_LATEST_TAG="$(git shortlog "$LATEST_TAG".."$COMMIT" --pretty="%h %s")"
-GITHUB_AUTH_HEADER="Authorization: token $GITHUB_OAUTH_TOKEN"
-
-CREATE_RELEASE_REQUEST=$(
-  jq -n \
-    --arg name "$VERSION" \
-    --arg commit "$COMMIT" \
-    --arg body "$MSGS_SINCE_LATEST_TAG" \
-    '{ tag_name: $name, name: $name, target_commitish: $commit, body: $body }')
-
-echo "Create release request:"
-echo "$CREATE_RELEASE_REQUEST"
-echo "**********************"
-
-CREATE_RELEASE_RESPONSE=$(
-  curl -s -X POST \
-    -H "$GITHUB_AUTH_HEADER" \
-    -d "$CREATE_RELEASE_REQUEST" \
-    "https://api.github.com/repos/$REPOSITORY/releases")
-
-echo "Create release response:"
-echo "$CREATE_RELEASE_RESPONSE"
-echo "**********************"
-
-RELEASE_UPLOAD_URL=$(
-  echo "$CREATE_RELEASE_RESPONSE" |
-    jq ".upload_url" |
-    sed "s/{?name,label}/?name=$PUBLISH_ZIP/" |
-    sed 's/"//g')
-
-echo "Upload url:"
-echo "$RELEASE_UPLOAD_URL"
-echo "**********************"
-
-UPLOAD_RESPONSE=$(
-  curl -s -X POST \
-    -H "$GITHUB_AUTH_HEADER" \
-    -H "Content-Type: application/octet-stream" \
-    --data-binary @"$PUBLISH_DIR/$PUBLISH_ZIP" \
-    "$RELEASE_UPLOAD_URL")
-
-echo "Upload response:"
-echo "$UPLOAD_RESPONSE"
-echo "**********************"
+rm -rf ./publish
+mkdir ./publish
+dotnet lambda package ./publish/package.zip -pl "$PROJECT" -c Release -farch arm64
+cp ./{serverless.yml,package.json,yarn.lock} ./publish
+[ -d "./serverless-artifacts" ] && cp -r ./serverless-artifacts ./publish
+zip -r "./publish/archive.zip" ./publish
+gh release create "$VERSION" "./publish/archive.zip" --generate-notes
+rm -rf ./publish

--- a/lib/strategies/local.js
+++ b/lib/strategies/local.js
@@ -7,7 +7,7 @@ export default {
   validate: _ => true,
   deploy: (env, version) => {
     // spawnSync('ls', ['-l'], { stdio: 'inherit' })
-    spawnSync('yarn', ['run', 'deploy', version, env], { stdio: 'inherit' })
+    spawnSync('yarn', ['run', 'gsda-deploy', version, env], { stdio: 'inherit' })
     return Promise.resolve()
   }
 } 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totallymoney/github-serverless-dotnet-artifacts",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "description": "Use github releases to publish and deploy serverless framework dotnet projects",
   "type": "module",
   "author": "totallymoney",

--- a/readme.md
+++ b/readme.md
@@ -6,9 +6,8 @@ Serverless packaging is performed [correctly](https://blair55.github.io/blog/ser
 
 ## Requirements
 
-* `jq`, `yarn`, `curl` & `dotnet` are available on the command line
-* `gh` is available if deployin using github workflow
-* `Amazon.Lambda.Tools` dotnet tool is installed in the target project
+* `yarn`, `gh` & `dotnet` are available on the command line
+* `Amazon.Lambda.Tools` dotnet tool is installed in the target dotnet repo:
 
 ```bash
 $ dotnet new tool-manifest
@@ -23,52 +22,46 @@ $ dotnet tool install Amazon.Lambda.Tools
 $ yarn add -D @totallymoney/github-serverless-dotnet-artifacts
 ```
 
-2. Add these scripts to your `package.json`
-
-```json
-"scripts": {
-  "publish": "gsda-publish <org/repo> <project_path>",
-  "deploy": "gsda-deploy <org/repo>",
-  "pick": "gsda-pick -e stage -e prod -c 5"
-}
-```
-
-* `<org/repo>` could be `mediaingenuity/myrepo` or `totallymoney/repo.name`
-* `<project_path>` could be `src` or `path/to/project.fsroj`
-* `-e` (multiple) are preset environments for `pick`
-* `-c` is the version list count for `pick`
-* both `-e` and `-c` have sensible defaults and can be overridden when `pick` is called
-
-3. Specify this package location in your `serverless.yml`
+2. Specify this package location in your `serverless.yml`
 
 ```yaml
 package:
   artifact: package.zip
 ```
 
-4. Add a `publish` step to your CI pipeline to create a github release
+3. Add a `publish` step to your CI pipeline to create a github release
 
 ```bash
-$ yarn run publish $VERSION $GITHASH
+$ yarn run gsda-publish $VERSION [ -p path/to/project ]
 ```
 
 - `$VERSION` is the github release name in [semver](http://semver.org) format
-- `$GITHASH` is the commit that triggered the build and will be tagged
+- `-p` is optional with a default value of `./src`
 
-5. Use the `deploy` command to update an enviroment
+4. Use the `deploy` command to update an enviroment
 
 ```bash
-$ yarn run deploy $VERSION $ENVIRONMENT
+$ yarn run gsda-deploy $VERSION $ENVIRONMENT
 ```
 
 - `$VERSION` is the github release to deploy
-- `$ENVIRONMENT` is the target environment (aka serverless `stage`)
+- `$ENVIRONMENT` is the target environment (aka serverless 'stage')
 
-6. Use `pick` for interactive deployments!
+5. Add a helper script to your `package.json` and use `pick` for interactive deployments!
+
+```json
+"scripts": {
+  "pick": "gsda-pick -e stage -e prod -c 5"
+}
+```
 
 ```bash
 $ yarn pick
 ```
+* `-e` (multiple) are preset environments for `pick`
+* `-c` is the version list count for `pick`
+* both `-e` and `-c` have sensible defaults and can be overridden when `pick` is called
+
 
 ## Development
 
@@ -78,3 +71,73 @@ Make sure you belong to the [totallymoney](https://www.npmjs.com/settings/totall
 $ git commit -am "Improve logging"
 $ yarn publish --access public
 ```
+
+
+## Migrating from 3.x.x to 4.x.x
+
+- [github cli](https://cli.github.com/) is required on your machine.
+
+  ```bash
+  $ brew install gh
+  # start interactive setup
+  $ gh auth login
+  ```
+
+- The `deploy` & `publish` npm scripts are now obselete.
+
+  Even in 3.x.x, these commands only existed as a _level of indirection_ to centralize input that could be called from more than one place and be burdensome to type. These commands are now less of a burden because the `gh` cli automatically recognises the repo it is operating on. We no longer need to "pin" the repo name with `deploy` & `publish` indirection commands, and can instead go straight to `gsda-deploy|publish`. We should, however, favour `gsda-pick` to manually deploy from the command line over `gsda-deploy`. `gsda-pick` now uses `gsda-deploy` internally, and no longer expects `deploy` to exist.
+
+  The positional arguments of `gsda-deploy` remain the same: version, then target environment. So if `deploy` is called by CI tooling, the only change required is to use `gsda-deploy` instead.
+
+  The removal of `publish` also avoids any confusion caused by "squatting" on the existing (npm|yarn) [`publish`](https://classic.yarnpkg.com/lang/en/docs/cli/publish/) command.
+
+- The project path of the `gsda-publish` command is provided via the optional `-p` flag.
+
+  If not specified, the project path defaults to `./src` which is the case for most projects. The version argument is still the first positional argument expected by `gsda-publish`. The command should be called directly from CI tooling, and called directly from the command line if ever needed outside of a CI context.
+  
+- The commit hash positional argument to the `gsda-publish` command is obselete.
+
+  Again, `gh` understands the context and will create a release from the current state of the repo, which will be checked out at the commit we wish to tag.
+
+- If building with CircleCI the [github-cli orb](https://circleci.com/developer/orbs/orb/circleci/github-cli) is required.
+
+  package.json
+  ```diff
+  "devDependencies": {
+  - "@totallymoney/github-serverless-dotnet-artifacts": "^3.2.0",
+  + "@totallymoney/github-serverless-dotnet-artifacts": "^4.0.0",
+  },
+  "scripts": {
+  - "publish": "gsda-publish org/repo proj/path",
+  - "deploy": "gsda-deploy org/repo",
+  }
+  ```
+
+  .github/workflows/build.yml
+  ```diff
+    - if: github.ref == 'refs/heads/main'
+  -   run: yarn run publish $VERSION $GITHUB_SHA
+  +   run: yarn run gsda-publish $VERSION -p proj/path
+      env:
+  -     GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  +     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        VERSION: 0.0.${{ github.run_number }}
+  ```
+
+  .circleci/config.yml
+  ```diff
+  + orbs:
+  +   github-cli: circleci/github-cli@2.3.0
+
+    - when:
+        condition:
+          equal: [ << pipeline.git.branch >>, main ]
+        steps:
+  +       - github-cli/setup:
+  +           token: GITHUB_OAUTH_TOKEN
+          - run:
+  -           command: yarn run publish $VERSION $CIRCLE_SHA1
+  +           command: yarn run gsda-publish $VERSION -p proj/path
+           environment:
+             VERSION: 0.0.<< pipeline.number >>
+  ```


### PR DESCRIPTION
This change demands that we all have the [github cli](https://cli.github.com/) installed, but it's worth it for the amount of code we can remove for a much reduced total cost of ownership (TCO). And I generally recommend leveraging `gh` in your workflows anyway!

The changes stem from the fact that `gh` knows which repo it's operating on. See the changes to the readme for details, and migration steps from 3.x.x.

After merging, this will become v4.0.0 due to the breaking changes.