### PR TITLE
Use tar to create release artifact

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -17,14 +17,14 @@ VERSION=$1
 ENVIRONMENT=$2
 NOW_ISO=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-rm -rf ./deploy
-mkdir ./deploy
-cd ./deploy
+rm -rf .gsda
+mkdir .gsda
+cd .gsda
 gh release view "$VERSION" | cat
-gh release download "$VERSION" --output ./deploy.zip
-tar --extract --verbose --file=./deploy.zip
+gh release download "$VERSION" --output archive.zip
+tar --extract --verbose --file=archive.zip
 yarn install --silent --no-progress --frozen-lockfile
 VERSION=$VERSION DEPLOYED_DATE=$NOW_ISO \
   yarn run sls deploy --stage "$ENVIRONMENT" --verbose
 cd .. || exit
-rm -rf ./deploy
+rm -rf .gsda

--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -25,11 +25,11 @@ while getopts "p::" opt; do
   esac
 done
 
-rm -rf ./publish
-mkdir ./publish
-dotnet lambda package ./publish/package.zip -pl "$PROJECT" -c Release -farch arm64 --msbuild-parameters /p:Version="$VERSION"
-cp ./{serverless.yml,package.json,yarn.lock} ./publish
-[ -d ./serverless-artifacts ] && cp -r ./serverless-artifacts ./publish
-tar --create --verbose --file=./publish/archive.zip --directory=./publish .
-gh release create "$VERSION" ./publish/archive.zip --generate-notes
-rm -rf ./publish
+rm -rf .gsda
+mkdir .gsda
+dotnet lambda package .gsda/package.zip -pl "$PROJECT" -c Release -farch arm64 --msbuild-parameters /p:Version="$VERSION"
+cp ./{serverless.yml,package.json,yarn.lock} .gsda
+[ -d ./serverless-artifacts ] && cp -r ./serverless-artifacts .gsda
+tar --create --verbose --file=.gsda/archive.zip --directory=.gsda .
+gh release create "$VERSION" .gsda/archive.zip --generate-notes
+rm -rf .gsda

--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-REQUIREMENTS="gh dotnet"
+REQUIREMENTS="gh dotnet tar"
 for i in $REQUIREMENTS; do
   hash "$i" 2>/dev/null || { echo "$0": I require "$i" but it\'s not installed.; exit 1; }
 done
@@ -29,9 +29,7 @@ rm -rf ./publish
 mkdir ./publish
 dotnet lambda package ./publish/package.zip -pl "$PROJECT" -c Release -farch arm64 --msbuild-parameters /p:Version="$VERSION"
 cp ./{serverless.yml,package.json,yarn.lock} ./publish
-[ -d "./serverless-artifacts" ] && cp -r ./serverless-artifacts ./publish
-cd ./publish
-zip -r archive.zip .
-cd ..
-gh release create "$VERSION" "./publish/archive.zip" --generate-notes
+[ -d ./serverless-artifacts ] && cp -r ./serverless-artifacts ./publish
+tar --create --verbose --file=./publish/archive.zip --directory=./publish .
+gh release create "$VERSION" ./publish/archive.zip --generate-notes
 rm -rf ./publish


### PR DESCRIPTION
Just means we won't need to install `zip` when publishing or deploying from within the dotnet image in CI.

Sticks to using the .zip extension so is compatible with artifacts that were created using `zip`.

Also now performs publish & deploy operations within a temporary `./.gsda` folder, instead of `./publish` & `./deploy`.